### PR TITLE
Fix problems with conflicting transactions.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 0.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix problems with conflicting transactions: only enqueue tasks when
+  transaction is successfully finished.
+  [jone]
 
 
 0.7.0 (2014-12-29)

--- a/src/collective/taskqueue/taskqueue.py
+++ b/src/collective/taskqueue/taskqueue.py
@@ -53,7 +53,7 @@ class TaskQueueTransactionDataManager(object):
         TaskQueueTransactionDataManager._COUNTER += 1
 
     def commit(self, t):
-        self.queue.put(self.task)
+        pass
 
     def sortKey(self):
         return self.sort_key
@@ -68,7 +68,7 @@ class TaskQueueTransactionDataManager(object):
         pass
 
     def tpc_finish(self, t):
-        pass
+        self.queue.put(self.task)
 
     def tpc_abort(self, t):
         pass


### PR DESCRIPTION
Only enqueue tasks when transaction is successfully finished.

When a transaction conflicts, the ISavepointDataManager's ``commit()`` method is called, followed by ``tpc_abort()``.
When the transaction is successful, ``commit()`` is called followed by ``tpc_finish()``.

Since we cannot roll back putting something in the queue we must enqueue the task in ``tpc_finish() and not in commit()``.
We assume that enqueueing a task does not fail.