### PR TITLE
Typo?

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,8 @@ Changelog
 0.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix profile so that it installs.
+  [gforcada]
 
 0.8.0 (2015-12-13)
 ------------------

--- a/src/collective/taskqueue/pasplugin/__init__.py
+++ b/src/collective/taskqueue/pasplugin/__init__.py
@@ -39,7 +39,8 @@ def configureTaskQueueAuthPlugin(context):
 
     if "taskauth" not in pas.objectIds():
         factory = pas.manage_addProduct["collective.taskqueue.pasplugin"]
-        factory.manage_addTaskQueueAuthPlugin(
+        taskauthplugin.manage_addTaskQueueAuthPlugin(
+            factory,
             "taskauth",
             "Task Queue PAS plugin"
         )


### PR DESCRIPTION
Without this change the Generic Setup profile refuses to install.

@datakurre I'm not sure if that's the proper fix, I was getting this traceback:

```
Traceback (most recent call last):
  File "/home/gil/.buildout/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py", line 400, in run_layer
    setup_layer(options, layer, setup_layers)
  File "/home/gil/.buildout/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py", line 708, in setup_layer
    setup_layer(options, base, setup_layers)
  File "/home/gil/.buildout/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py", line 713, in setup_layer
    layer.setUp()
  File "/home/gil/.buildout/eggs/plone.app.testing-4.2.5-py2.7.egg/plone/app/testing/helpers.py", line 343, in setUp
    self.setUpPloneSite(portal)
  File "/home/gil/Documents/freitag/git/zope/src/der.freitag/src/der/freitag/testing.py", line 309, in setUpPloneSite
    applyProfile(portal, 'der.freitag:default')
  File "/home/gil/.buildout/eggs/plone.app.testing-4.2.5-py2.7.egg/plone/app/testing/helpers.py", line 113, in applyProfile
    setupTool.runAllImportStepsFromProfile(profileId)
  File "/home/gil/.buildout/eggs/Products.GenericSetup-1.7.7-py2.7.egg/Products/GenericSetup/tool.py", line 365, in runAllImportStepsFromProfile
    blacklisted_steps=blacklisted_steps)
   - __traceback_info__: profile-der.freitag:default
  File "/home/gil/.buildout/eggs/Products.GenericSetup-1.7.7-py2.7.egg/Products/GenericSetup/tool.py", line 1184, in _runImportStepsFromContext
    message = self._doRunImportStep(step, context)
  File "/home/gil/.buildout/eggs/Products.GenericSetup-1.7.7-py2.7.egg/Products/GenericSetup/tool.py", line 1095, in _doRunImportStep
    return handler(context)
   - __traceback_info__: taskqueue-pasplugin
  File "/home/gil/Documents/freitag/git/zope/src/collective.taskqueue/src/collective/taskqueue/pasplugin/__init__.py", line 43, in configureTaskQueueAuthPlugin
    factory.manage_addTaskQueueAuthPlugin(
AttributeError: manage_addTaskQueueAuthPlugin


```
