### PR TITLE
Plone 5.2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,9 @@ Changelog
 - use `@implementer` decorator
   [petschki]
 
+- Make it work on Plone 5.2.
+  [gforcada]
+
 0.8.2 (2017-01-03)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ setup(
         'Framework :: Plone',
         'Framework :: Plone :: 4.3',
         'Framework :: Plone :: 5.0',
+        'Framework :: Plone :: 5.1',
+        'Framework :: Plone :: 5.2',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',

--- a/src/collective/taskqueue/pasplugin/__init__.py
+++ b/src/collective/taskqueue/pasplugin/__init__.py
@@ -7,7 +7,7 @@ from Products.PluggableAuthService.interfaces.plugins import (
     IExtractionPlugin,
     IAuthenticationPlugin
 )
-from Products.PlonePAS.Extensions.Install import activatePluginInterfaces
+from Products.PlonePAS.setuphandlers import activatePluginInterfaces
 from AccessControl.Permissions import add_user_folders
 from Products.PluggableAuthService import PluggableAuthService
 


### PR DESCRIPTION
On `Products.PlonePAS` the `Extensions` package got removed on version 6.x (used by Plone 5.2.x) but the code was actually moved to the `setuphandlers` module since version 5.x (used by Plone 4.3.x, 5.0. and 5.1.x).

With this `collective.taskqueue` should work on Plone 5.2 with Python 2.7